### PR TITLE
added resources from Brown University

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ You are welcome to be a collaborator, -- you can make an issue/pull request, and
 
 9. (Prof Scott E. Fahlman@CMU) **Quora answers on the LTI program at CMU** (2017). [[Article](https://www.quora.com/What-does-the-admissions-committee-process-for-graduate-school-look-like-Do-you-sit-in-a-room-and-all-discuss-the-same-candidate-at-the-same-time-or-is-it-more-of-an-individual-process-with-opinions-aggregated-at-the-end)]
 
+10. (Albert Webson et al., PhDs@Brown University) **Resources for Underrepresented Groups, including Brown's Own Applicant Mentorship Program** (2020, but we will keep updating it throughout the 2021 application season.) [[List of Resources](https://cs.brown.edu/degrees/doctoral/applications/helpful-resources-applying-computer-science-phd-programs/)]
+
 ### Specific Suggestions
 
 1. (Prof Nathan Schneider@Georgetown University) **Inside Ph.D. admissions: What readers look for in a Statement of Purpose**. [[Article](https://nschneid.medium.com/inside-ph-d-admissions-what-readers-look-for-in-a-statement-of-purpose-3db4e6081f80)]


### PR DESCRIPTION
Hi Zhijing, thanks for creating this repository! 

As part of an informal working group on promoting diversity and inclusion in CS, a few of my grad friends and I have also compiled a list of resources for PhD applicants with a focus on historically underrepresented groups. Perhaps most importantly, we offer a mentorship program where we match applicants (mostly by research area) to PhD volunteers at Brown CS, who can give individual feedback on their applications, plus hosting Zoom panel events etc. where we can answer questions informally. 

I don't think Brown CS invented applicant mentorship programs like this; a number of other big-name universities were also offering similar programs last year. We tried to link to their programs as well on our website, but I think it might be more up-to-date if everyone can contribute to your repo instead.